### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/src/utils/regex/stringUtils.ts
+++ b/src/utils/regex/stringUtils.ts
@@ -97,5 +97,11 @@ export function getPathSegsFromId(id: string): string[] {
 }
 
 export function escapeMarkdown(text: string): string {
-  return text.replace(/`/g, "\\`").replace(/\*/g, "\\*").replace(/_/g, "\\_").replace(/#/g, "\\#").replace(/~/g, "\\~");
+  return text
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+    .replace(/\*/g, "\\*")
+    .replace(/_/g, "\\_")
+    .replace(/#/g, "\\#")
+    .replace(/~/g, "\\~");
 }


### PR DESCRIPTION
Potential fix for [https://github.com/baimohui/i18n-mage/security/code-scanning/7](https://github.com/baimohui/i18n-mage/security/code-scanning/7)

To fix the issue, we should update the `escapeMarkdown` function so that it also escapes backslashes (`\`) by replacing each occurrence of `\` with `\\`, in addition to the other escape sequences. Critically, when chaining `.replace()` calls to escape multiple characters, we must ensure that the backslash replacement is performed first, otherwise later replacements could double-escape backslashes that we just inserted. Therefore, in `escapeMarkdown`, the first `.replace()` should target `/\\/g, "\\\\"`, followed by the other meta-characters as is done now.

The required change is to update the function implementation on line 100 (in `escapeMarkdown`) to start by escaping all backslashes. No new external dependencies are needed; only a change to the order and inclusion of one additional `.replace()` call is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
