### PR TITLE
Potential fix for code scanning alert no. 8: Overly permissive regular expression range

### DIFF
--- a/src/utils/regex/formatUtils.ts
+++ b/src/utils/regex/formatUtils.ts
@@ -105,7 +105,7 @@ export function validateLang(str: string, lang: string): boolean {
       res = /[\u0900-\u097F]/.test(str);
       break;
     case "vi": // 越南语
-      res = /[a-zA-ZÀ-ỹĀ-ỹăâđêôơưáàảãạấầẩẫậắằẳẵặéèẻẽẹếềểễệíìỉĩịóòỏõọốồổỗộớờởỡợúùủũụứừửữựýỳỷỹỵ]/i.test(str);
+      res = /[a-zA-Zăâđêôơưáàảãạấầẩẫậắằẳẵặéèẻẽẹếềểễệíìỉĩịóòỏõọốồổỗộớờởỡợúùủũụứừửữựýỳỷỹỵ]/i.test(str);
       break;
     default:
       res = true; // 未知语言默认通过


### PR DESCRIPTION
Potential fix for [https://github.com/baimohui/i18n-mage/security/code-scanning/8](https://github.com/baimohui/i18n-mage/security/code-scanning/8)

**How to fix:**  
To precisely match the Vietnamese alphabet and its accented variants, avoid using the broad range `À-ỹ` (U+00C0–U+1EF9), as it contains many non-Vietnamese characters. The best fix is to only include characters that are actually used in Vietnamese. Since the regular expression already enumerates almost all variant Vietnamese letters (lowercase, uppercase, with and without diacritics) elsewhere in the character class, simply remove the `À-ỹ` (and similar wide ranges) and retain the explicitly listed characters.

**Detailed plan:**  
- Edit line 108, replacing the character class 
  ```
  [a-zA-ZÀ-ỹĀ-ỹăâđêôơưáàảãạấầẩẫậắằẳẵặéèẻẽẹếềểễệíìỉĩịóòỏõọốồổỗộớờởỡợúùủũụứừửữựýỳỷỹỵ]
  ```
  with an enumeration of characters used for Vietnamese.
- Remove broad ranges like `À-ỹ` and `Ā-ỹ` (if present).
- Ensure only intended letters, numbers, and perhaps whitespace are included.
- No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
